### PR TITLE
Fix font reference and nav markup

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <style>
   @font-face {
     font-family: 'ColdagSerif';
-    src: url('/fonts/ColdagSerif.woff2') format('woff2');
+    src: url('/fonts/ColdagSerif-Bold.otf') format('opentype');
     font-weight: normal;
     font-style: normal;
   }
@@ -37,9 +37,8 @@
       <div class="text-white text-lg font-bold uppercase">MOBRO ©</div>
       <hr class="border-t border-white flex-grow mx-6 opacity-50" />
       <a href="#contact" class="text-white text-lg font-bold uppercase hover:opacity-80 transition">
-  Contact
-</a>
-      >
+        Contact
+      </a>
     </nav>
 
   <header class="relative h-screen w-full overflow-hidden flex items-center justify-center text-center px-6 md:px-16">

--- a/src/style.css
+++ b/src/style.css
@@ -4,7 +4,7 @@
 
 @font-face {
   font-family: 'ColdagSerif';
-  src: url('/fonts/ColdagSerif-Regular.otf') format('opentype');
+  src: url('/fonts/ColdagSerif-Bold.otf') format('opentype');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
## Summary
- fix invalid font path and stray `>` in nav

## Testing
- `npm run build` *(fails: vite permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_686a25d98cec832ebdc08dd00c70c539